### PR TITLE
remove promise to resolve immediately

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/rrweb",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "record and replay the web",
   "scripts": {
     "test": "npm run bundle:browser && cross-env TS_NODE_CACHE=false TS_NODE_FILES=true mocha -r ts-node/register -r ignore-styles -r jsdom-global/register test/**.test.ts",

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -512,9 +512,7 @@ export class Replayer {
         break;
       }
     }
-    Promise.resolve().then(() =>
-      this.service.send({ type: 'REPLACE_EVENTS', payload: { events } }),
-    );
+    this.service.send({ type: 'REPLACE_EVENTS', payload: { events } });
   }
 
   public enableInteract() {


### PR DESCRIPTION
- for instances where `replaceEvents` was followed by a `play` / `pause`, they were executing out of order