### PR TITLE
[HIG-2269] ensure invalid DOM nesting doesn't crash rrweb

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/rrweb",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "record and replay the web",
   "scripts": {
     "test": "npm run bundle:browser && cross-env TS_NODE_CACHE=false TS_NODE_FILES=true mocha -r ts-node/register -r ignore-styles -r jsdom-global/register test/**.test.ts",

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1964,9 +1964,15 @@ export class Replayer {
     ) {
       ((parent as unknown) as HTMLTextAreaElement).value = frag.textContent;
     }
-    parent.appendChild(frag);
-    // restore state of elements after they are mounted
-    this.restoreState(parent);
+    try {
+      parent.appendChild(frag);
+      // restore state of elements after they are mounted
+      this.restoreState(parent);
+    } catch (error) {
+      // this is likely due to a recording with
+      // invalid DOM nesting (a div under a p). don't crash rrweb in this case.
+      console.warn(error)
+    }
   }
 
   /**


### PR DESCRIPTION
Replaying an app with invalid DOM nesting may crash rrweb.
Print console warning instead of crashing.
