### PR TITLE
fix client mutation observer check

### DIFF
--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/rrweb",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -279,7 +279,9 @@ export default class MutationBuffer {
       // ensure shadowHost is a Node, or doc.contains will throw an error
       const notInDoc =
         !this.doc.contains(n) &&
-        (!rootShadowHost || !this.doc.contains(rootShadowHost));
+        (!rootShadowHost ||
+          !(rootShadowHost instanceof Node) ||
+          !this.doc.contains(rootShadowHost));
       if (!n.parentNode || notInDoc) {
         return;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -517,6 +517,19 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@highlight-run/rrweb@2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@highlight-run/rrweb/-/rrweb-2.1.8.tgz#0fc0d05202bb5253937333f38fcc8c8c365b91f7"
+  integrity sha512-3xcH5Ew6l3thkaPyxh7e2YORO7XUFW89JAuP6W65qJMjg9TIVokaVSfnrg+eMOVvUs3XS3FAaOUU64q4M8whaQ==
+  dependencies:
+    "@highlight-run/rrdom" "0.1.17"
+    "@highlight-run/rrweb-snapshot" "1.1.30"
+    "@types/css-font-loading-module" "0.0.7"
+    "@xstate/fsm" "^1.4.0"
+    base64-arraybuffer "^1.0.1"
+    fflate "^0.4.4"
+    mitt "^3.0.0"
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz"


### PR DESCRIPTION
ensure the element on which `.contains()` is called is a node.