### PR TITLE
ensure media elements have their source blocked correctly

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -21,6 +21,7 @@ import {
   obfuscateText,
   isNativeShadowDom,
   getCssRulesString,
+  isElementSrcBlocked,
 } from './utils';
 
 let _id = 1;
@@ -815,16 +816,20 @@ function serializeElementNode(
     }
   }
   // block element
-  if (needBlock || needMask || (tagName === 'img' && enableStrictPrivacy)) {
+  if (
+    needBlock ||
+    needMask ||
+    (enableStrictPrivacy && isElementSrcBlocked(tagName))
+  ) {
     const { width, height } = n.getBoundingClientRect();
     attributes = {
       class: attributes.class,
       rr_width: `${width}px`,
       rr_height: `${height}px`,
     };
-    if (enableStrictPrivacy) {
-      needBlock = true;
-    }
+  }
+  if (enableStrictPrivacy && isElementSrcBlocked(tagName)) {
+    needBlock = true;
   }
   // iframe
   if (tagName === 'iframe' && !keepIframeSrcFn(attributes.src as string)) {
@@ -1069,10 +1074,10 @@ export function serializeNodeWithId(
       !!serializedNode.needMask;
 
     /** Highlight Code Begin */
-    // Remove the image's src if enableStrictPrivacy.
-    if (strictPrivacy && serializedNode.tagName === 'img') {
+    // process enableStrictPrivacy obfuscation of non-text elements
+    if (strictPrivacy && isElementSrcBlocked(serializedNode.tagName)) {
       const clone = n.cloneNode();
-      (clone as unknown as HTMLImageElement).src = '';
+      (clone as unknown as { src: string }).src = '';
       mirror.add(clone, serializedNode);
     }
     /** Highlight Code End */

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -202,4 +202,15 @@ export function obfuscateText(text: string): string {
       .join(' ') || '';
   return text;
 }
+
+// returns true if the tag name is an element type that should have its source blocked
+export function isElementSrcBlocked(tagName: string): boolean {
+  return (
+    tagName === 'img' ||
+    tagName === 'video' ||
+    tagName === 'audio' ||
+    tagName === 'source'
+  );
+}
+
 /* End of Highlight Code */


### PR DESCRIPTION
* Fixes a bug in the `needsMask` processing that would stop recording children if `highlight-mask` was set on a div with `enableStrictPrivacy` set globally.
* Adds source obfuscation for other media elements: video, audio, and source.

Testing:
before the fix - https://app.highlight.io/649/sessions/o5jfoC9BXXjBkxqwpVbNNDWK3hcI
after the fix - https://app.highlight.io/649/sessions/9DR6a5arNtGacbkr2pwyPn5ENh3E