### PR TITLE
Specify typescript version in packages

### DIFF
--- a/packages/rrdom-nodejs/package.json
+++ b/packages/rrdom-nodejs/package.json
@@ -41,7 +41,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
     "rollup-plugin-web-worker-loader": "^1.6.1",
-    "ts-jest": "27.1.5"
+    "ts-jest": "27.1.5",
+    "typescript": "^4.7.3"
   },
   "dependencies": {
     "@highlight-run/rrdom": "workspace:*",

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -43,7 +43,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
     "rollup-plugin-web-worker-loader": "^1.6.1",
-    "ts-jest": "27.1.5"
+    "ts-jest": "27.1.5",
+    "typescript": "^4.7.3"
   },
   "dependencies": {
     "@highlight-run/rrweb-snapshot": "workspace:*"

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -22,7 +22,8 @@
     "svelte": "^3.2.0",
     "svelte-check": "^1.4.0",
     "svelte-preprocess": "^4.0.0",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "typescript": "^4.7.3"
   },
   "dependencies": {
     "@highlight-run/rrweb": "workspace:*",

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -26,7 +26,8 @@
     "vite": "^3.1.8",
     "vite-plugin-web-extension": "^1.4.5",
     "vite-plugin-zip-pack": "^1.0.5",
-    "webextension-polyfill": "^0.10.0"
+    "webextension-polyfill": "^0.10.0",
+    "typescript": "^4.7.3"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.3.4",


### PR DESCRIPTION
Hopefully fixes the build errors in https://github.com/highlight/highlight/pull/5239

Somehow these were getting resolved to the root workspace level typescript version 5 in that PR.