### PR TITLE
fix recording of webgl2 canvases

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -321,6 +321,7 @@ function record<T = eventWithTime>(
     mirror,
     sampling: sampling?.canvas?.fps,
     clearWebGLBuffer: sampling?.canvas?.clearWebGLBuffer,
+    initialSnapshotDelay: sampling?.canvas?.initialSnapshotDelay,
     dataURLOptions,
     resizeFactor: sampling?.canvas?.resizeFactor,
     maxSnapshotDimension: sampling?.canvas?.maxSnapshotDimension,

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -320,6 +320,7 @@ function record<T = eventWithTime>(
     blockSelector,
     mirror,
     sampling: sampling?.canvas?.fps,
+    clearWebGLBuffer: sampling?.canvas?.clearWebGLBuffer,
     dataURLOptions,
     resizeFactor: sampling?.canvas?.resizeFactor,
     maxSnapshotDimension: sampling?.canvas?.maxSnapshotDimension,

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -73,6 +73,7 @@ export class CanvasManager {
     mirror: Mirror;
     sampling?: 'all' | number;
     clearWebGLBuffer?: boolean;
+    initialSnapshotDelay?: number;
     dataURLOptions: DataURLOptions;
     resizeFactor?: number;
     maxSnapshotDimension?: number;
@@ -89,6 +90,7 @@ export class CanvasManager {
       recordCanvas,
       recordVideos,
       clearWebGLBuffer,
+      initialSnapshotDelay,
       dataURLOptions,
     } = options;
     this.mutationCb = options.mutationCb;
@@ -106,6 +108,7 @@ export class CanvasManager {
         blockSelector,
         {
           clearWebGLBuffer,
+          initialSnapshotDelay,
           dataURLOptions,
         },
         options.resizeFactor,
@@ -154,6 +157,7 @@ export class CanvasManager {
     blockSelector: string | null,
     options: {
       clearWebGLBuffer?: boolean;
+      initialSnapshotDelay?: number;
       dataURLOptions: DataURLOptions;
     },
     resizeFactor?: number,
@@ -404,16 +408,21 @@ export class CanvasManager {
           }
         }),
       );
-      await Promise.all(promises);
+      Promise.all(promises).catch(console.error);
 
       rafId = requestAnimationFrame(takeSnapshots);
     };
 
-    rafId = requestAnimationFrame(takeSnapshots);
+    const delay = setTimeout(() => {
+      rafId = requestAnimationFrame(takeSnapshots);
+    }, options.initialSnapshotDelay);
 
     this.resetObservers = () => {
       canvasContextReset();
-      cancelAnimationFrame(rafId);
+      clearTimeout(delay);
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+      }
     };
   }
 

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -281,12 +281,7 @@ export class CanvasManager {
                 this.debug(
                   canvas,
                   'cleared webgl canvas to load it into memory',
-                  {
-                    base64: canvas.toDataURL(
-                      options.dataURLOptions.type,
-                      options.dataURLOptions.quality,
-                    ),
-                  },
+                  { attributes: context?.getContextAttributes() },
                 );
               }
             }

--- a/packages/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
+++ b/packages/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
@@ -71,11 +71,26 @@ worker.onmessage = async function (e) {
     // on first try we should check if canvas is transparent,
     // no need to save it's contents in that case
     if (!lastBlobMap.has(id) && (await transparentBase64) === base64) {
+      console.debug('[highlight-worker] canvas bitmap is transparent', {
+        id,
+        base64,
+      });
       lastBlobMap.set(id, base64);
-      return worker.postMessage({ id });
+      return worker.postMessage({ id, status: 'transparent' });
     }
 
-    if (lastBlobMap.get(id) === base64) return worker.postMessage({ id }); // unchanged
+    // unchanged
+    if (lastBlobMap.get(id) === base64) {
+      console.debug('[highlight-worker] canvas bitmap is unchanged', {
+        id,
+        base64,
+      });
+      return worker.postMessage({ id, status: 'unchanged' });
+    }
+    console.debug('[highlight-worker] canvas bitmap processed', {
+      id,
+      base64,
+    });
     worker.postMessage({
       id,
       type,
@@ -89,6 +104,9 @@ worker.onmessage = async function (e) {
     });
     lastBlobMap.set(id, base64);
   } else {
-    return worker.postMessage({ id: e.data.id });
+    console.debug('[highlight-worker] no offscreencanvas support', {
+      id: e.data.id,
+    });
+    return worker.postMessage({ id: e.data.id, status: 'unsupported' });
   }
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -214,6 +214,10 @@ export type CanvasSamplingStrategy = Partial<{
    */
   clearWebGLBuffer?: boolean;
   /**
+   * Time (in milliseconds) to wait before the initial snapshot of canvas/video elements.
+   */
+  initialSnapshotDelay?: number;
+  /**
    * Adjust the quality of the canvas blob serialization.
    */
   dataURLOptions?: DataURLOptions;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -542,6 +542,7 @@ export type ImageBitmapDataURLWorkerParams = {
 export type ImageBitmapDataURLWorkerResponse =
   | {
       id: number;
+      status: string;
     }
   | {
       id: number;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -208,6 +208,12 @@ export type CanvasSamplingStrategy = Partial<{
    */
   maxSnapshotDimension: number;
   /**
+   * Default behavior for WebGL canvas elements with `preserveDrawingBuffer: false` is to clear the buffer to
+   * load the canvas into memory to avoid getting a transparent bitmap.
+   * Set to false to disable the clearing (in case there are visual glitches in the canvas).
+   */
+  clearWebGLBuffer?: boolean;
+  /**
    * Adjust the quality of the canvas blob serialization.
    */
   dataURLOptions?: DataURLOptions;


### PR DESCRIPTION
webgl2 canvases created after highlight would start recording with the `preserveDrawingBuffer: false`
setting would not record correctly because we would snapshot a transparent image of the canvas.
instead of trying to clear the canvas, we should create a context with `preserveDrawingBuffer: true` to
ensure that the canvas can be recorded (tested in babylon.js)
https://app.highlight.io/1/sessions/n7P0x5XTItCqEN7B7pmtJVldUzJo