### PR TITLE
remove debug logging in canvas worker

### DIFF
--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -105,6 +105,7 @@ export class CanvasManager {
 
     this.worker =
       new ImageBitmapDataURLWorker() as ImageBitmapDataURLRequestWorker;
+    this.worker.debug = !!this.logger;
     this.worker.onmessage = (e) => {
       const { id } = e.data;
       this.snapshotInProgressMap.set(id, false);

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -105,7 +105,6 @@ export class CanvasManager {
 
     this.worker =
       new ImageBitmapDataURLWorker() as ImageBitmapDataURLRequestWorker;
-    this.worker.debug = !!this.logger;
     this.worker.onmessage = (e) => {
       const { id } = e.data;
       this.snapshotInProgressMap.set(id, false);
@@ -290,6 +289,7 @@ export class CanvasManager {
           dw: element.width,
           dh: element.height,
           dataURLOptions: this.options.dataURLOptions,
+          logDebug: !!this.logger,
         },
         [bitmap],
       );
@@ -455,6 +455,7 @@ export class CanvasManager {
                   dw: outputWidth,
                   dh: outputHeight,
                   dataURLOptions: options.dataURLOptions,
+                  logDebug: !!this.logger,
                 },
                 [bitmap],
               );

--- a/packages/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
+++ b/packages/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
@@ -14,7 +14,6 @@ export interface ImageBitmapDataURLRequestWorker {
     transfer?: [ImageBitmap],
   ) => void;
   onmessage: (message: MessageEvent<ImageBitmapDataURLWorkerResponse>) => void;
-  debug?: boolean;
 }
 
 interface ImageBitmapDataURLResponseWorker {
@@ -22,7 +21,6 @@ interface ImageBitmapDataURLResponseWorker {
     | null
     | ((message: MessageEvent<ImageBitmapDataURLWorkerParams>) => void);
   postMessage(e: ImageBitmapDataURLWorkerResponse): void;
-  debug?: boolean;
 }
 
 async function getTransparentBlobFor(
@@ -45,17 +43,18 @@ async function getTransparentBlobFor(
   }
 }
 
-// `as any` because: https://github.com/Microsoft/TypeScript/issues/20595
 const worker: ImageBitmapDataURLResponseWorker = self;
+let logDebug: boolean = false;
 
 const debug = (...args: any[]) => {
-  if (worker.debug) {
+  if (logDebug) {
     console.debug(...args);
   }
 };
 
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 worker.onmessage = async function (e) {
+  logDebug = !!e.data.logDebug;
   if ('OffscreenCanvas' in globalThis) {
     const { id, bitmap, width, height, dx, dy, dw, dh, dataURLOptions } =
       e.data;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -553,6 +553,7 @@ export type ImageBitmapDataURLWorkerParams = {
   dy: number;
   dw: number;
   dh: number;
+  logDebug?: boolean;
 };
 
 export type ImageBitmapDataURLWorkerResponse =


### PR DESCRIPTION
Recent snapshot improvements introduced debug logging that is noisy.
This change defaults to no canvas web-worker logging but
allows using the `debug` H.init setting to enable it.