### PR TITLE
Fix infinite loop in replaceActions

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -54,7 +54,6 @@ import type {
   incrementalData,
   Handler,
   Emitter,
-  metaEvent,
   mutationData,
   scrollData,
   inputData,
@@ -403,7 +402,7 @@ export class Replayer {
       (e) => e.type === EventType.FullSnapshot,
     );
     if (firstMeta) {
-      const { width, height } = firstMeta.data as metaEvent['data'];
+      const { width, height } = firstMeta.data ;
       setTimeout(() => {
         this.emitter.emit(ReplayerEvents.Resize, {
           width,
@@ -2019,7 +2018,7 @@ export class Replayer {
                 const svp = styleValues[s] as styleValueWithPriority;
                 targetEl.style.setProperty(s, svp[0], svp[1]);
               } else {
-                const svs = styleValues[s] as string;
+                const svs = styleValues[s] ;
                 targetEl.style.setProperty(s, svs);
               }
             }
@@ -2252,7 +2251,7 @@ export class Replayer {
     const adoptStyleSheets = (targetHost: Node, styleIds: number[]) => {
       const stylesToAdopt = styleIds
         .map((styleId) => this.styleMirror.getStyle(styleId))
-        .filter((style) => style !== null) as CSSStyleSheet[];
+        .filter((style) => style !== null);
       if (hasShadowRoot(targetHost))
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         (targetHost as HTMLElement).shadowRoot!.adoptedStyleSheets =

--- a/packages/rrweb/src/replay/timer.ts
+++ b/packages/rrweb/src/replay/timer.ts
@@ -52,8 +52,14 @@ export class Timer {
   }
 
   public replaceActions(actions: actionWithDelay[]) {
+    const rafWasActive = this.raf === true;
+
     this.actions.length = 0;
-    this.actions.splice(0, 0, ...actions);
+    this.actions = [...actions];
+
+    if (rafWasActive) {
+      this.raf = requestAnimationFrame(this.rafCheck.bind(this));
+    }
   }
   /* End Highlight Code */
 


### PR DESCRIPTION
We were seeing issues getting into an infinite loop calling `splice` to reset actions (I believe only with large action sets). Replacing the array completely seems to get around this issue.